### PR TITLE
fixed saving for data-state attribute selection boxes in popup

### DIFF
--- a/Shared (Extension)/Resources/popup.js
+++ b/Shared (Extension)/Resources/popup.js
@@ -402,7 +402,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     
                     filteredElements.forEach(function (element) {
                         var key = element + "Status";
-                        browser.storage.sync.set({ [key]: document.getElementById(element + "Toggle").checked });
+                        var element = document.getElementById(element+"Toggle");
+                        var value = (element.getAttribute("data-state") != null) ?
+                                                        element.getAttribute("data-state") :
+                                                        element.checked;
+                        browser.storage.sync.set({ [key]: value });
                     });
                 }
             });


### PR DESCRIPTION
Solves #32 by adding a check if the _data-state_ attribute is set, and saves that rather than .checked if it is set.

This solution assumes either .checked or _data-state_ is used. Both would break it.

EDIT: This fix is tested locally and works on my end