### PR TITLE
Adds Reddit and support for injecting to shadow-DOMs

### DIFF
--- a/Shared (Extension)/Resources/content.js
+++ b/Shared (Extension)/Resources/content.js
@@ -20,7 +20,7 @@
                                       "instagramFeed", "instagramStories", "instagramMutedStories", "instagramExplore", "instagramReels", "instagramSuggestions", "instagramComments",
                                       "whatsappPreview","whatsappNotificationPrompt",
                                       "googleAds", "googleBackground",
-                                      "redditFeed", "redditPopular", "redditAll", "redditRecent", "redditCommunities", "redditNotification", "redditChat"];
+                                      "redditFeed", "redditPopular", "redditAll", "redditRecent", "redditCommunities", "redditNotification", "redditChat", "redditTrending", "redditPopularCommunities"];
     
     // YouTube CSS
     const youtubeSearchCssOn = '';
@@ -181,6 +181,10 @@
     const redditNotificationCssOff = "#mini-inbox-tooltip { display: none; }"
     const redditChatCssOn = ""
     const redditChatCssOff = "reddit-chat-header-button { display: none; }"
+    const redditTrendingCssOn = ""
+    const redditTrendingCssOff = "[search-telemetry-source='popular_carousel'] { display: none; }"
+    const redditPopularCommunitiesCssOn = ""
+    const redditPopularCommunitiesCssOff = "#popular-communities-list { display: none; }  [aria-label='Popular Communities'] { display: none; }"
     
     
     // Used for telling the application that the CSS modified is within a shadow-dom.

--- a/Shared (Extension)/Resources/content.js
+++ b/Shared (Extension)/Resources/content.js
@@ -10,7 +10,7 @@
     }
     window.hasRun = true;
     
-    const platformsWeTarget = [ "youtube", "facebook", "x", "instagram", "linkedin", "whatsapp", "google" ];
+    const platformsWeTarget = [ "youtube", "facebook", "x", "instagram", "linkedin", "whatsapp", "google", "reddit" ];
     const elementsThatCanBeHidden = [ "youtubeSearch", "youtubeSearchPredict", "youtubeRecVids", "youtubeThumbnails", "youtubeNotifications", "youtubeProfileImg",
                                       "youtubeShorts", "youtubeSubscriptions", "youtubeLibrary", "youtubeHistory", "youtubeExplore", "youtubeMore",
                                       "youtubeRelated", "youtubeSidebar", "youtubeComments", "youtubeAds", "youtubeViews", "youtubeLikes", "youtubeSubscribers",
@@ -19,7 +19,8 @@
                                       "linkedinNews", "linkedinNotifications", "linkedinFeed", "linkedinAds",
                                       "instagramFeed", "instagramStories", "instagramMutedStories", "instagramExplore", "instagramReels", "instagramSuggestions", "instagramComments",
                                       "whatsappPreview","whatsappNotificationPrompt",
-                                      "googleAds", "googleBackground" ];
+                                      "googleAds", "googleBackground",
+                                      "redditFeed", "redditPopular", "redditAll", "redditRecent", "redditCommunities", "redditNotification", "redditChat"];
     
     // YouTube CSS
     const youtubeSearchCssOn = '';
@@ -165,15 +166,42 @@
     const googleBackgroundCssOff = '#tads, #atvcap .ptJHdc.yY236b.c3mZkd, #tads .CnP9N.U3A9Ac.irmCpc,.commercial-unit-mobile-top,.commercial-unit-mobile-top .v7hl4d,.commercial-unit-mobile-bottom .v7hl4d {background-color: #F2E6C3 !important;}'
     const googleBackgroundCssOn = ''
     
+    // Reddit CSS
+    const redditFeedCssOn = ""
+    const redditFeedCssOff = "shreddit-feed { display: none; }"
+    const redditPopularCssOn = ""
+    const redditPopularCssOff = "a[href='/r/popular/'] { display: none; }"
+    const redditAllCssOn = ""
+    const redditAllCssOff = "a[href='/r/all/'] { display: none; }"
+    const redditRecentCssOn = ""
+    const redditRecentCssOff = "reddit-recent-pages { display: none; }"
+    const redditCommunitiesCssOn = ""
+    const redditCommunitiesCssOff = "[aria-controls='communities_section'] + faceplate-auto-height-animator { display: none; }   [aria-controls='communities_section'] { display: none; }"
+    const redditNotificationCssOn = ""
+    const redditNotificationCssOff = "#mini-inbox-tooltip { display: none; }"
+    const redditChatCssOn = ""
+    const redditChatCssOff = "reddit-chat-header-button { display: none; }"
+    
+    
+    // Used for telling the application that the CSS modified is within a shadow-dom.
+    // If a variable is declared in this dict, the style is appended in the given CSS selector
+    const shadowSelectors = {
+        "redditPopular": "left-nav-top-section",
+        "redditAll": "left-nav-top-section",
+    }
+    
     
     // function to create style element with the specified CSS content
     function createStyleElement(some_style_id, some_css){
-        if(!document.getElementById(some_style_id)){
+        const elementToHide = some_style_id.replace("Style", "");
+        const dom = (elementToHide in shadowSelectors) ? document.querySelector(shadowSelectors[elementToHide]).shadowRoot : document.head;
+        //const dom = document;
+        if(!dom.querySelector("#" + some_style_id)){
             var styleElement = document.createElement("style");
             styleElement.id = some_style_id;
-            document.head.appendChild(styleElement).innerHTML = some_css;
+            dom.appendChild(styleElement).innerHTML = some_css;
         } else {
-            document.getElementById(some_style_id).innerHTML = some_css;
+            dom.querySelector("#" + some_style_id).innerHTML = some_css;
         };
     };
     
@@ -253,7 +281,9 @@
     
     // let the content script toggle elements when the popup asks for it
     browser.runtime.onMessage.addListener((message) => {
-        var currentStyle = document.getElementById(message.element + "Style");
+        const dom = (message.element in shadowSelectors) ? document.querySelector(shadowSelectors[message.element]).shadowRoot : document.head;
+        //const dom = document;
+        var currentStyle = dom.querySelector("#" + message.element + "Style");
         
         if(message.method === "change"){
             if (currentStyle == undefined){

--- a/Shared (Extension)/Resources/manifest.json
+++ b/Shared (Extension)/Resources/manifest.json
@@ -4,7 +4,7 @@
 
     "name": "MindShield",
     "description": "Hide distractions on the web (YT, FB, IG, TW, LI, Google).",
-    "version": "1.20",
+    "version": "1.21",
 
     "icons": {
         "48":  "images/icon-48.png",

--- a/Shared (Extension)/Resources/manifest.json
+++ b/Shared (Extension)/Resources/manifest.json
@@ -17,7 +17,7 @@
     "content_scripts": [{
         "css": [ "style.css" ],
         "js": [ "content.js" ],
-        "matches": [ "*://web.whatsapp.com/*", "*://www.youtube.com/*", "*://m.youtube.com/*", "*://www.facebook.com/*", "*://m.facebook.com/*", 
+        "matches": [ "*://web.whatsapp.com/*", "*://www.youtube.com/*", "*://m.youtube.com/*", "*://www.facebook.com/*", "*://m.facebook.com/*",
             "*://x.com/*",
             "*://www.instagram.com/*", "*://www.linkedin.com/*",
             "*://www.google.com/*",
@@ -47,7 +47,9 @@
             "*://www.google.com.co/*",
             "*://www.google.pl/*",
             "*://www.google.pt/*",
-            "*://www.google.com.pk/*"]
+            "*://www.google.com.pk/*",
+            "*://www.reddit.com/*",
+            "*://reddit.com/*"]
     }],
 
     "browser_action": {

--- a/Shared (Extension)/Resources/popup.html
+++ b/Shared (Extension)/Resources/popup.html
@@ -353,6 +353,14 @@
                         <input type="checkbox" id="redditChatToggle" name="redditChatToggle">
                             <label for="redditChatToggle">Chat</label>
                     </div>
+                    <div class="a-toggle">
+                        <input type="checkbox" id="redditTrendingToggle" name="redditTrendingToggle">
+                            <label for="redditTrendingToggle">Trending topics</label>
+                    </div>
+                    <div class="a-toggle">
+                        <input type="checkbox" id="redditPopularCommunitiesToggle" name="redditPopularCommunitiesToggle">
+                            <label for="redditPopularCommunitiesToggle">Popular communities</label>
+                    </div>
                 </div>
             </div>
             

--- a/Shared (Extension)/Resources/popup.html
+++ b/Shared (Extension)/Resources/popup.html
@@ -70,6 +70,13 @@
                             <span class="slider round"></span>
                     </label>
                 </div>
+                <div id="toggle-reddit" class="website-toggle">
+                    <p class="website-label">Reddit</p>
+                    <label class="switch">
+                        <input type="checkbox" id="redditSwitch" checked>
+                            <span class="slider round"></span>
+                    </label>
+                </div>
             </div>
             <div id="what-sites">
                 <div id="sites-arrow-right" style="display: inline-block;">
@@ -91,6 +98,7 @@
                   <li><a href="https://www.linkedin.com" target="_blank">linkedin.com</a></li>
                   <li class="platform-ipad-mac"><a href="https://web.whatsapp.com" target="_blank">web.whatsapp.com</a></li>
                   <li><a href="https://www.google.com" target="_blank">google.com</a></li>
+                  <li><a href="https://www.reddit.com" target="_blank">reddit.com</a></li>
                 </ul>
             </div>
             <div class="dropdown youtube">
@@ -311,6 +319,39 @@
                     <div class="a-toggle platform-ipad-mac">
                         <input type="checkbox" id="linkedinAdsToggle" name="linkedinAdsToggle">
                             <label for="linkedinAdsToggle">Ads</label>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="dropdown reddit">
+                <div class="toggle-group hide-checkboxes">
+                    <div class="a-toggle">
+                        <input type="checkbox" id="redditFeedToggle" name="redditFeedToggle">
+                            <label for="redditFeedToggle">Feed</label>
+                    </div>
+                    <div class="a-toggle">
+                        <input type="checkbox" id="redditPopularToggle" name="redditPopularToggle">
+                            <label for="redditPopularToggle">Popular-sidebar</label>
+                    </div>
+                    <div class="a-toggle">
+                        <input type="checkbox" id="redditAllToggle" name="redditAllToggle">
+                            <label for="redditAllToggle">All-sidebar</label>
+                    </div>
+                    <div class="a-toggle">
+                        <input type="checkbox" id="redditRecentToggle" name="redditRecentToggle">
+                            <label for="redditRecentToggle">Recent-sidebar</label>
+                    </div>
+                    <div class="a-toggle">
+                        <input type="checkbox" id="redditCommunitiesToggle" name="redditCommunitiesToggle">
+                            <label for="redditCommunitiesToggle">Communities-sidebar</label>
+                    </div>
+                    <div class="a-toggle">
+                        <input type="checkbox" id="redditNotificationToggle" name="redditNotificationToggle">
+                            <label for="redditNotificationToggle">Notifications</label>
+                    </div>
+                    <div class="a-toggle">
+                        <input type="checkbox" id="redditChatToggle" name="redditChatToggle">
+                            <label for="redditChatToggle">Chat</label>
                     </div>
                 </div>
             </div>

--- a/Shared (Extension)/Resources/popup.js
+++ b/Shared (Extension)/Resources/popup.js
@@ -2,7 +2,7 @@
 // https://developer.chrome.com/docs/extensions/mv3/messaging/
 
 document.addEventListener('DOMContentLoaded', function() {
-    const platformsWeTarget = [ "youtube", "facebook", "x", "instagram", "linkedin", "whatsapp", "google" ];
+    const platformsWeTarget = [ "youtube", "facebook", "x", "instagram", "linkedin", "whatsapp", "google", "reddit" ];
     const elementsThatCanBeHidden = [ "youtubeSearch", "youtubeSearchPredict", "youtubeRecVids", "youtubeThumbnails", "youtubeNotifications", "youtubeProfileImg",
                                       "youtubeShorts", "youtubeSubscriptions", "youtubeLibrary", "youtubeHistory", "youtubeExplore", "youtubeMore",
                                       "youtubeRelated", "youtubeSidebar", "youtubeComments", "youtubeAds", "youtubeViews", "youtubeLikes", "youtubeSubscribers",
@@ -11,7 +11,8 @@ document.addEventListener('DOMContentLoaded', function() {
                                       "linkedinNews", "linkedinNotifications", "linkedinFeed", "linkedinAds",
                                       "instagramFeed", "instagramStories", "instagramMutedStories", "instagramExplore", "instagramReels", "instagramSuggestions", "instagramComments",
                                       "whatsappPreview","whatsappNotificationPrompt",
-                                      "googleAds", "googleBackground" ];
+                                      "googleAds", "googleBackground",
+                                      "redditFeed", "redditPopular", "redditAll", "redditRecent", "redditCommunities", "redditNotification", "redditChat"];
     
     
     // Initialize or increment the open count in localStorage

--- a/Shared (Extension)/Resources/popup.js
+++ b/Shared (Extension)/Resources/popup.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                       "instagramFeed", "instagramStories", "instagramMutedStories", "instagramExplore", "instagramReels", "instagramSuggestions", "instagramComments",
                                       "whatsappPreview","whatsappNotificationPrompt",
                                       "googleAds", "googleBackground",
-                                      "redditFeed", "redditPopular", "redditAll", "redditRecent", "redditCommunities", "redditNotification", "redditChat"];
+                                      "redditFeed", "redditPopular", "redditAll", "redditRecent", "redditCommunities", "redditNotification", "redditChat", "redditTrending", "redditPopularCommunities"];
     
     
     // Initialize or increment the open count in localStorage


### PR DESCRIPTION
Handles #37 and #6 

#37 through a dictionary of hideable elements as key, with a CSS-selector string as value. 
https://github.com/SuneGraversen/mindshield-open-source/blob/ef4837fa5124fe088746f388fa48323cf7dfd5b4/Shared%20(Extension)/Resources/content.js#L186C1-L191C6

The extension then assumes the CSS-selector represents a unique method to find the root of the shadow DOM, and either injects scripts into the shadowRoot or the head of the document-dom.
https://github.com/SuneGraversen/mindshield-open-source/blob/ef4837fa5124fe088746f388fa48323cf7dfd5b4/Shared%20(Extension)/Resources/content.js#L197C8-L205C11