### PR TITLE
small tweaks to add firefox android support

### DIFF
--- a/Digital Habits Focus.xcodeproj/project.pbxproj
+++ b/Digital Habits Focus.xcodeproj/project.pbxproj
@@ -809,7 +809,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_TEAM = JD647S9RT6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -821,7 +821,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 6.9.1;
+				MARKETING_VERSION = 6.9.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -842,7 +842,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_TEAM = JD647S9RT6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -854,7 +854,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 6.9.1;
+				MARKETING_VERSION = 6.9.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -878,7 +878,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_TEAM = JD647S9RT6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -894,7 +894,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.9.1;
+				MARKETING_VERSION = 6.9.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -918,7 +918,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_TEAM = JD647S9RT6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -934,7 +934,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.9.1;
+				MARKETING_VERSION = 6.9.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -958,7 +958,7 @@
 				CODE_SIGN_ENTITLEMENTS = "macOS (Extension)/MindShield.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = JD647S9RT6;
 				ENABLE_APP_SANDBOX = YES;
@@ -974,7 +974,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 6.9.1;
+				MARKETING_VERSION = 6.9.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -996,7 +996,7 @@
 				CODE_SIGN_ENTITLEMENTS = "macOS (Extension)/MindShield.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = JD647S9RT6;
 				ENABLE_APP_SANDBOX = YES;
@@ -1012,7 +1012,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 6.9.1;
+				MARKETING_VERSION = 6.9.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1036,7 +1036,7 @@
 				CODE_SIGN_ENTITLEMENTS = "macOS (App)/MindShield.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = JD647S9RT6;
 				ENABLE_APP_SANDBOX = YES;
@@ -1053,7 +1053,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 6.9.1;
+				MARKETING_VERSION = 6.9.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1078,7 +1078,7 @@
 				CODE_SIGN_ENTITLEMENTS = "macOS (App)/MindShield.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = JD647S9RT6;
 				ENABLE_APP_SANDBOX = YES;
@@ -1095,7 +1095,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 6.9.1;
+				MARKETING_VERSION = 6.9.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/Shared (Extension)/Resources/manifest.json
+++ b/Shared (Extension)/Resources/manifest.json
@@ -3,7 +3,7 @@
   "default_locale": "en",
   "name": "Digital Habits: Focus",
   "description": "Hide distractions on any site (YouTube, Instagram, LinkedIn, and more).",
-  "version": "6.9.1",
+  "version": "6.9.2",
   "icons": {
     "48": "images/icon-48.png",
     "96": "images/icon-96.png",
@@ -68,6 +68,7 @@
           "none"
         ]
       }
-    }
+    },
+    "gecko_android": {}
   }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,15 @@ platform tags, and Internal). Store “What’s New” / AMO notes are generated
 `scripts/changelog-to-store-whats-new.js` (excludes Internal; keeps untagged
 plus platform-relevant tags; strips markdown).
 
+## v6.9.2
+
+This update comes with some under-the-hood improvements.
+
+### Internal
+
+- [firefox] Adjusted the extension package to prepare for Firefox for Android
+  support.
+
 ## v6.9.1
 
 This update comes with some design improvements.

--- a/scripts/build-extension-zip.sh
+++ b/scripts/build-extension-zip.sh
@@ -4,6 +4,13 @@
 # scripts/build-edge-extension-zip.sh — Partner Center rejects the dual
 # background.service_worker + background.scripts keys in this package.
 #
+# Strips the `nativeMessaging` permission from the packaged manifest only
+# (never the committed source, which Xcode uses as-is for the Safari build).
+# background.js gates that whole feature behind IS_SAFARI (detected via
+# Safari's safari-web-extension:// scheme), so it's already dead code on
+# Chrome/Firefox — but Firefox for Android refuses to install any add-on
+# that merely declares the permission unless it's privileged-signed.
+#
 # Usage:
 #   ./scripts/build-extension-zip.sh
 #   ./scripts/build-extension-zip.sh 6.7.0
@@ -26,9 +33,30 @@ mkdir -p "$OUT_DIR"
 ZIP_NAME="digital-habits-focus-v${VERSION}.zip"
 ZIP_PATH="$OUT_DIR/$ZIP_NAME"
 
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cp -R "$RESOURCES"/. "$TMP/"
+
+PACKAGE_TMP="$TMP" node <<'EOF'
+const fs = require('fs');
+const path = require('path');
+const manifestPath = path.join(process.env.PACKAGE_TMP, 'manifest.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+if (!manifest.permissions || !manifest.permissions.includes('nativeMessaging')) {
+  console.error('Expected nativeMessaging permission in source manifest.');
+  process.exit(1);
+}
+manifest.permissions = manifest.permissions.filter((p) => p !== 'nativeMessaging');
+
+fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+console.log('Stripped nativeMessaging permission (Safari-only; blocks Firefox for Android installs).');
+EOF
+
 rm -f "$ZIP_PATH"
 (
-  cd "$RESOURCES"
+  cd "$TMP"
   zip -r "$ZIP_PATH" . \
     -x "*.DS_Store" \
     -x "**/.DS_Store" \


### PR DESCRIPTION
the extension currently only works on desktop firefox, not firefox for android — annoying, since most of my doomscrolling happens on my phone. The extension is already one cross-browser webExtension (same code as Chrome/safari), so its was a small fix

two things were blocking android installs:

1. `manifest.json` never declared `gecko_android`, which Firefox requires before treating an add-on as Android-compatible at all.
2. The `nativeMessaging` permission — used only for a safari-only companion-app sync feature (`background.js` gates it behind `IS_SAFARI`) — is treated as **privileged** on Android and blocks installation outright.

## changed

- `manifest.json`: added `"gecko_android": {}` (Chrome/Safari ignore this key).
- `scripts/build-extension-zip.sh`: strips `nativeMessaging` from the packaged manifest only, for the Chrome/Firefox zip. The source manifest stays untouched, so Safari's Xcode build keeps it.
- Bumped to `6.9.2` with a changelog entry.


tested on a real Android phone via `adb` + `web-ext run -t firefox-android` against the actual built zip — installs cleanly.

## note

This makes the package installable. Showing up for Android users on AMO also needs the "compatible with Firefox for Android" toggle flipped in the listing, separately.
